### PR TITLE
Integrated Let's Encrypt for HTTPS-support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = scan/ssllabs-scan
 	url = git@github.com:ssllabs/ssllabs-scan.git
 	branch = stable
+[submodule "letsencrypt"]
+	path = letsencrypt
+	url = git@github.com:letsencrypt/letsencrypt.git

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ cd scan/wpscan
 bundle install --without test --path vendor/bundle
 </pre>
 
+**Let's encrypt**
+
+Run the letsencrypt-auto file in order for Let's encrypt to install its dependencies. 
+
+<pre>
+cd letsencrypt
+./letsencrypt-auto
+</pre>
+
+**Configuration**
+
 Copy the example configuration file.
 
 <pre>
@@ -88,22 +99,23 @@ adminMail=admin@example.com
 basePath=/srv
 </pre>
 
-Add the update script to roots crontab:
+Add the update and renewCert scripts to roots crontab:
 
 <pre>
 sudo crontab -e
 </pre>
 
-Add this line to check for update once a day:
+Add this line to check for update once a day, and renew certs once a month at the first:
 
 <pre>
 min hour * * * /PATH/TO/PROJECT/DIR/update/updateWP.bash
+min hour 1 * * /PATH/TO/PROJECT/DIR/update/renewCerts.bash
 </pre>
 
 
 ## Installing a Wordpress site
 
-Run the script installWP.bash with username and fully qualified domain name (FQDN) as arguments:
+Run the script installWP.bash with username and fully qualified domain name (FQDN) as arguments. IMPORTANT! **The FQDN must be correctly configured and pointing to the host that's running the script.**
 
 <pre>
 sudo ./installWP.bash USER FQDN
@@ -117,3 +129,4 @@ Add the username for the site to the list of userNames in config file:
 # Site name = user name that executes the site.
 userNames="org1 org2"
 </pre>
+

--- a/delete/README.md
+++ b/delete/README.md
@@ -1,0 +1,7 @@
+# Delete WP-site
+
+To delete a previously installed WP-site - change to this directory and run:
+
+<pre>
+sudo ./deleteWPInstall.bash userName FQDN
+</pre>

--- a/delete/deleteWPInstall.bash
+++ b/delete/deleteWPInstall.bash
@@ -14,6 +14,7 @@ source ../conf
 
 userName=$1
 FQDN=$2
+letsencryptFolder=/etc/letsencrypt
 
 # Remove users and DBs
 userdel $userName
@@ -27,7 +28,19 @@ rm -f /etc/nginx/sites-enabled/$FQDN
 rm -f /etc/nginx/sites-available/$FQDN
 rm -f /etc/php5/fpm/pool.d/$FQDN.conf
 
+# Revoke certificate. Will try to revoke all certs. 
+for certificate in $(ls $letsencryptFolder/archive/$FQDN | grep "cert")
+do
+	echo "Revoking cert $certificate"
+	../letsencrypt/letsencrypt-auto revoke --cert-path $letsencryptFolder/archive/$FQDN/$certificate
+	echo ""
+done
+# Remove config for domain
+rm -f $letsencryptFolder/$FQDN.cli.ini
+
 # Remove WP-install
 rm -rf $basePath/$userName
 rm -rf /home/$userName/.wp-cli
+
+systemctl reload nginx php5-fpm
 

--- a/install/installWP.bash
+++ b/install/installWP.bash
@@ -59,3 +59,4 @@ echo ""
 echo "This is the password for WP-administrator-user $adminUser:"
 echo $wpAdminPassword
 echo ""
+

--- a/install/letsencrypt.bash
+++ b/install/letsencrypt.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [[ $# != 2 || $S1 == "-h" || $S1 == "--help" ]]
+then
+        echo "Usage: "
+        echo "  $0 userName FQDN"
+        exit 1
+fi
+
+userName=$1
+FQDN=$2
+configFile=/etc/letsencrypt/"$FQDN".cli.ini
+
+scriptDir="$(dirname $0)"
+cd $scriptDir
+# Read config file with paths to WP-installs and usernames
+source ../conf
+
+# Create configfolder+file if letsencrypt hasn't run yet
+mkdir -p /etc/letsencrypt
+touch $configFile
+
+# Create a config file for domain
+cat > $configFile << EOF
+# Use a 4096 bit RSA key instead of 2048
+rsa-key-size = 4096
+
+# Uncomment and update to register with the specified e-mail address
+email = $adminMail
+
+# Uncomment and update to generate certificates for the specified
+# domains.
+domains = $FQDN
+
+# Uncomment to use the webroot authenticator. Replace webroot-path with the
+# path to the public_html / webroot folder being served by your web server.
+authenticator = webroot
+webroot-path = $basePath/$userName/wordpress
+
+EOF
+
+# There's a bug in the letsencrypt client which forces us to create some folders 
+# for it in the webroot, and set root as owner, before we run the client. 
+# https://community.letsencrypt.org/t/webroot-plugin-the-client-lacks-sufficient-authorization/5479/2
+mkdir -p $basePath/$userName/wordpress/.well-known/acme-challenge
+chown -R root $basePath/$userName/wordpress/.well-known
+
+# Run letsencrypt and get cert
+../letsencrypt/letsencrypt-auto certonly --renew-by-default --config $configFile
+
+

--- a/install/nginx.bash
+++ b/install/nginx.bash
@@ -21,43 +21,74 @@ source ../conf
 mkdir -p /var/log/nginx/$FQDN
 touch $configFile
 
+# Initial conf for letsencrypt to work
 cat > $configFile << EOF
 server {
+	listen 80;
 	server_name $FQDN *.$FQDN;
+	
+	root $basePath/$userName/wordpress;
+	
+	location ~* .well-known* {
+	autoindex on;
+	}
+	
+	location / {
+		rewrite ^ https://$FQDN;
+	}
+}
 
+EOF
+
+# If site is not enabled already, enable it
+ln -sf $configFile /etc/nginx/sites-enabled
+# Reload nginx so that letsencrypt can get cert
+systemctl reload nginx
+
+# Run letsencrypt to get cert
+echo "Running letsencrypt to generate certificate for site!"
+echo ""
+./letsencrypt.bash $userName $FQDN
+
+# SSL conf
+cat >> $configFile << EOF
+server {
+	listen 443;
+	server_name $FQDN;
+	ssl on;
+	
+	ssl_certificate /etc/letsencrypt/live/$FQDN/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/$FQDN/privkey.pem;
+	
+	add_header Cache-Control "public";
+	
 	error_log /var/log/nginx/$FQDN/error.log;
 	access_log /var/log/nginx/$FQDN/access.log;
-
+	
 	root $basePath/$userName/wordpress;
 	index index.php index.html index.htm;
 	client_max_body_size 50m;
-
-
+	
+	
 	location = /favicon.ico {
 		log_not_found off;
 		access_log off;
 	}
-
+	
 	# Allow robots to scan without flooding server
 	location = /robots.txt {
 		allow all;
 		log_not_found off;
 		access_log off;
 	}
-
-	# Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
-	# Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
-	location ~ /\. {
-		deny all;
-	}
-
+	
 	# Deny access to any files with a .php extension in the uploads directory
 	# Works in sub-directory installs and also in multisite network
 	location ~* /(?:uploads|files)/.*\.php$ {
 		deny all;
 	}
 	# End og restrictions -----------------
-
+	
 	location ~ \.php$ {
 		try_files \$uri =404;
 		fastcgi_pass unix:/srv/$userName/socket/php-fpm.sock;
@@ -70,5 +101,5 @@ server {
 EOF
 
 # Activate site
-ln -s $configFile /etc/nginx/sites-enabled
 service nginx reload
+

--- a/update/renewCerts.bash
+++ b/update/renewCerts.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+scriptDir="$(dirname $0)"
+cd $scriptDir
+# Read config file with paths to WP-installs and usernames
+source ../conf
+
+letsencFolder=/etc/letsencrypt
+
+# Update all certs with cli.ini file in folder for Let's Encrypt
+for configFile in $(ls $letsencFolder/*.cli.ini); do
+	echo "Renewing cert using $configFile"
+	../letsencrypt/letsencrypt-auto certonly --renew-by-default --config $configFile
+	echo ""
+done
+


### PR DESCRIPTION
Instructions to the tester of this branch/PR: 

1. Install wp-cli version >= 0.21.1. Others won't work with WP >= 4.4
2. This branch needs testing using two sites/domains, one for upgrading and one for clean install
3. First add the domains in the DNS-server configuration for your domain AND MAKE SURE THEY ARE CORRECTLY CONFIGURED
4. Create a WP site using the master branch for one of these domains (let's call it "first")
5. Checkout this branch (encrypt)
6. Get the submodule for letsencrypt ("git submodule update --init --recursive" in root of repo)
7. Run the script letsencrypt-auto in the letsencrypt folder
8. Create a site using this new version for the other domain (let's call it "second") - check if the site works
9. Run the nginx-script on the second domain (sudo ./nginx.bash SECOND SECOND.TLD)
