### PR TITLE
Smart renewal

### DIFF
--- a/conf.example
+++ b/conf.example
@@ -8,6 +8,8 @@ basePath=/srv
 # Site name = user name that executes the site.
 userNames="org1 org2"
 
+# Expiry limit in days before renewing certificates
+expLimit=30
 
 ##
 # You don't have to touch the definitions beyond this point.

--- a/install/nginx.bash
+++ b/install/nginx.bash
@@ -87,6 +87,11 @@ server {
 	location ~* /(?:uploads|files)/.*\.php$ {
 		deny all;
 	}
+	
+	location ~ ~$ {
+		deny all;
+	}
+	
 	# End og restrictions -----------------
 	
 	location ~ \.php$ {

--- a/update/renewCerts.bash
+++ b/update/renewCerts.bash
@@ -6,7 +6,6 @@ cd $scriptDir
 source ../conf
 
 letsencFolder=/etc/letsencrypt
-expLimit=30
 dateNow=$(date -d "now" +%s)
 
 

--- a/update/renewCerts.bash
+++ b/update/renewCerts.bash
@@ -15,18 +15,20 @@ for configFile in $(ls $letsencFolder/*.cli.ini); do
 	
 	primaryDomain=`grep "^\s*domains" $configFile | sed "s/^\s*domains\s*=\s*//" | sed 's/(\s*)\|,.*$//'`
 	certFile=/etc/letsencrypt/live/$primaryDomain/fullchain.pem
-	
 	expDate=$(date -d "`openssl x509 -in $certFile -text -noout | grep "Not After" | cut -c 25-`" +%s)
 	expDays=$(echo \( $expDate - $dateNow \) / 86400 |bc)
 	
+	
+	echo "-------"
 	if [ "$expDays" -gt "$expLimit" ]
 	then
 		echo "The certificate for $primaryDomain is up to date, no need for renewal, $expDays days left."
 	else
 		echo "Renewing cert for $primaryDomain using $configFile"
 		../letsencrypt/letsencrypt-auto certonly --renew-by-default --config $configFile
-		echo ""
 	fi
+	
+	echo ""
 done
 
 systemctl reload nginx

--- a/update/renewCerts.bash
+++ b/update/renewCerts.bash
@@ -8,12 +8,18 @@ source ../conf
 letsencFolder=/etc/letsencrypt
 dateNow=$(date -d "now" +%s)
 
+if [ -z $expLimit ]
+then
+	echo "Expiry date not set in conf. See conf.example for example."
+	exit 1
+fi
+
 
 # Update all certs with cli.ini file in folder for Let's Encrypt
 for configFile in $(ls $letsencFolder/*.cli.ini); do
 	
 	primaryDomain=`grep "^\s*domains" $configFile | sed "s/^\s*domains\s*=\s*//" | sed 's/(\s*)\|,.*$//'`
-	certFile=/etc/letsencrypt/live/$primaryDomain/fullchain.pem
+	certFile=$letsencFolder/live/$primaryDomain/fullchain.pem
 	expDate=$(date -d "`openssl x509 -in $certFile -text -noout | grep "Not After" | cut -c 25-`" +%s)
 	expDays=$(echo \( $expDate - $dateNow \) / 86400 |bc)
 	


### PR DESCRIPTION
This renewal script checks whether a certificate needs renewal or not before renewing it. If there's no need to renew, renewal will not be done. 